### PR TITLE
[Mission 2-1] Virtual DOM을 실제 DOM으로 렌더링하기

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,9 @@
-import Content from './components/Content';
-import Header from './components/Header';
-
 export default function App() {
   return (
     <>
-      <Header />
-      <Content />
+      <h1 style={{ color: 'blue' }}>React Test</h1>
+      <p>렌더링 테스트 중입니다.</p>
+      <button onClick={() => alert('클릭!')}>버튼</button>
     </>
   );
 }

--- a/src/lib/createRoot.js
+++ b/src/lib/createRoot.js
@@ -1,0 +1,10 @@
+import render from './render.js';
+
+export function createRoot(container) {
+  return {
+    render(vdom) {
+      container.innerHTML = '';
+      render(vdom, container);
+    },
+  };
+}

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -42,12 +42,17 @@ function createDOM(vdom) {
 
   // children 처리
   const children = vdom.props?.children;
+
+  if (children == null) {
+    return;
+  }
+
   if (Array.isArray(children)) {
     children.forEach((child) => {
       const childDOM = createDOM(child);
       if (childDOM) dom.appendChild(childDOM);
     });
-  } else if (children != null) {
+  } else {
     const childDOM = createDOM(children);
     if (childDOM) dom.appendChild(childDOM);
   }

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -18,18 +18,25 @@ function createDOM(vdom) {
       ? document.createDocumentFragment()
       : document.createElement(vdom.type);
 
+  const propsKeyMap = {
+    className: 'class',
+    htmlFor: 'for',
+  };
+
   // props 처리
   for (const [key, value] of Object.entries(vdom.props || {})) {
     if (key === 'children') continue;
 
-    if (key === 'style' && typeof value === 'object') {
+    const actualKey = propsKeyMap[key] || key;
+
+    if (actualKey === 'style' && typeof value === 'object') {
       Object.assign(dom.style ?? {}, value);
-    } else if (key.startsWith('on')) {
-      dom.addEventListener(key.slice(2).toLowerCase(), value);
-    } else if (key in dom) {
-      dom[key] = value;
+    } else if (actualKey.startsWith('on')) {
+      dom.addEventListener(actualKey.slice(2).toLowerCase(), value);
+    } else if (actualKey in dom) {
+      dom[actualKey] = value;
     } else {
-      dom.setAttribute?.(key, value);
+      dom.setAttribute?.(actualKey, value);
     }
   }
 

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -4,6 +4,10 @@ export default function render(vdom, container) {
 }
 
 function createDOM(vdom) {
+  if (vdom === null || vdom === undefined || typeof vdom === 'boolean') {
+    return document.createTextNode('');
+  }
+
   if (typeof vdom === 'string' || typeof vdom === 'number') {
     return document.createTextNode(vdom);
   }
@@ -33,7 +37,7 @@ function createDOM(vdom) {
   const children = vdom.props?.children;
   if (Array.isArray(children)) {
     children.forEach((child) => dom.appendChild(createDOM(child)));
-  } else if (children) {
+  } else if (children != null) {
     dom.appendChild(createDOM(children));
   }
 

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -27,7 +27,9 @@ function createDOM(vdom) {
 
   for (const [key, value] of Object.entries(vdom.props || {})) {
     if (key === 'children') continue;
-    if (key.startsWith('on')) {
+    if (key === 'style' && typeof value === 'object') {
+      Object.assign(dom.style, value);
+    } else if (key.startsWith('on')) {
       dom.addEventListener(key.slice(2).toLowerCase(), value);
     } else {
       dom.setAttribute(key, value);

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -5,7 +5,7 @@ export default function render(vdom, container) {
 
 function createDOM(vdom) {
   if (vdom === null || vdom === undefined || typeof vdom === 'boolean') {
-    return document.createTextNode('');
+    return null;
   }
 
   if (typeof vdom === 'string' || typeof vdom === 'number') {
@@ -38,9 +38,13 @@ function createDOM(vdom) {
 
   const children = vdom.props?.children;
   if (Array.isArray(children)) {
-    children.forEach((child) => dom.appendChild(createDOM(child)));
+    children.forEach((child) => {
+      const childDOM = createDOM(child);
+      if (childDOM) dom.appendChild(childDOM);
+    });
   } else if (children != null) {
-    dom.appendChild(createDOM(children));
+    const childDOM = createDOM(children);
+    if (childDOM) dom.appendChild(childDOM);
   }
 
   return dom;

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -12,30 +12,28 @@ function createDOM(vdom) {
     return document.createTextNode(vdom);
   }
 
-  if (vdom.type === 'Fragment') {
-    const fragment = document.createDocumentFragment();
-    const children = vdom.props?.children;
-    if (Array.isArray(children)) {
-      children.forEach((child) => fragment.appendChild(createDOM(child)));
-    } else if (children != null) {
-      fragment.appendChild(createDOM(children));
-    }
-    return fragment;
-  }
+  // 노드 생성
+  const dom =
+    vdom.type === 'Fragment'
+      ? document.createDocumentFragment()
+      : document.createElement(vdom.type);
 
-  const dom = document.createElement(vdom.type);
-
+  // props 처리
   for (const [key, value] of Object.entries(vdom.props || {})) {
     if (key === 'children') continue;
+
     if (key === 'style' && typeof value === 'object') {
-      Object.assign(dom.style, value);
+      Object.assign(dom.style ?? {}, value);
     } else if (key.startsWith('on')) {
       dom.addEventListener(key.slice(2).toLowerCase(), value);
+    } else if (key in dom) {
+      dom[key] = value;
     } else {
-      dom.setAttribute(key, value);
+      dom.setAttribute?.(key, value);
     }
   }
 
+  // children 처리
   const children = vdom.props?.children;
   if (Array.isArray(children)) {
     children.forEach((child) => {

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -1,0 +1,39 @@
+export default function render(vdom, container) {
+  const el = createDOM(vdom);
+  container.appendChild(el);
+}
+
+function createDOM(vdom) {
+  if (typeof vdom === 'string' || typeof vdom === 'number') {
+    return document.createTextNode(vdom);
+  }
+
+  if (vdom.type === 'Fragment') {
+    const fragment = document.createDocumentFragment();
+    const children = Array.isArray(vdom.props.children)
+      ? vdom.props.children
+      : [vdom.props.children];
+    children.forEach((child) => fragment.appendChild(createDOM(child)));
+    return fragment;
+  }
+
+  const dom = document.createElement(vdom.type);
+
+  for (const [key, value] of Object.entries(vdom.props || {})) {
+    if (key === 'children') continue;
+    if (key.startsWith('on')) {
+      dom.addEventListener(key.slice(2).toLowerCase(), value);
+    } else {
+      dom.setAttribute(key, value);
+    }
+  }
+
+  const children = vdom.props?.children;
+  if (Array.isArray(children)) {
+    children.forEach((child) => dom.appendChild(createDOM(child)));
+  } else if (children) {
+    dom.appendChild(createDOM(children));
+  }
+
+  return dom;
+}

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -10,10 +10,12 @@ function createDOM(vdom) {
 
   if (vdom.type === 'Fragment') {
     const fragment = document.createDocumentFragment();
-    const children = Array.isArray(vdom.props.children)
-      ? vdom.props.children
-      : [vdom.props.children];
-    children.forEach((child) => fragment.appendChild(createDOM(child)));
+    const children = vdom.props?.children;
+    if (Array.isArray(children)) {
+      children.forEach((child) => fragment.appendChild(createDOM(child)));
+    } else if (children != null) {
+      fragment.appendChild(createDOM(children));
+    }
     return fragment;
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,10 @@
 import App from './App';
-import render from './lib/render';
+import { createRoot } from './lib/createRoot';
 
 const app = App();
 console.log(JSON.stringify(app, null, 2));
 
-const root = document.getElementById('app');
-render(app, root);
+const rootEl = document.getElementById('app');
+const root = createRoot(rootEl);
+
+root.render(App());

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,8 @@
 import App from './App';
+import render from './lib/render';
 
 const app = App();
 console.log(JSON.stringify(app, null, 2));
+
+const root = document.getElementById('app');
+render(app, root);


### PR DESCRIPTION
## [Mission 2-1] Virtual DOM을 실제 DOM으로 렌더링하기 #5
### 1. 작업 내용
- `render` 함수 구현
- `createRoot` 함수 구현

### 2. render 함수
```js
export default function render(vdom, container) {
  const el = createDOM(vdom);
  container.appendChild(el);
}

function createDOM(vdom) {
  if (vdom === null || vdom === undefined || typeof vdom === 'boolean') {
    return document.createTextNode('');
  }

  if (typeof vdom === 'string' || typeof vdom === 'number') {
    return document.createTextNode(vdom);
  }

  if (vdom.type === 'Fragment') {
    const fragment = document.createDocumentFragment();
    const children = vdom.props?.children;
    if (Array.isArray(children)) {
      children.forEach((child) => fragment.appendChild(createDOM(child)));
    } else if (children != null) {
      fragment.appendChild(createDOM(children));
    }
    return fragment;
  }

  const dom = document.createElement(vdom.type);

  for (const [key, value] of Object.entries(vdom.props || {})) {
    if (key === 'children') continue;
    if (key === 'style' && typeof value === 'object') {
      Object.assign(dom.style, value);
    } else if (key.startsWith('on')) {
      dom.addEventListener(key.slice(2).toLowerCase(), value);
    } else {
      dom.setAttribute(key, value);
    }
  }

  const children = vdom.props?.children;
  if (Array.isArray(children)) {
    children.forEach((child) => dom.appendChild(createDOM(child)));
  } else if (children != null) {
    dom.appendChild(createDOM(children));
  }

  return dom;
}
```
1. 값 타입 분기 처리
- null, undefined, boolean → 빈 텍스트 노드 생성
- string, number → 텍스트 노드 생성

2. Fragment 처리 (<></>)
- DocumentFragment 생성 후 자식 노드 재귀 렌더링

3. DOM 요소 생성 및 props 적용
- children은 별도로 처리
- style은 element.style에 직접 적용
- onClick 등 이벤트는 addEventListener로 바인딩
- 나머지 속성은 setAttribute로 처리

4. 자식 노드 렌더링
- createDOM() 재귀 호출 후 부모에 추가

### 3. createRoot 함수
```js
import render from './render.js';

export function createRoot(container) {
  return {
    render(vdom) {
      container.innerHTML = '';
      render(vdom, container);
    },
  };
}
```
```js
// main.js
import App from './App';
import { createRoot } from './lib/createRoot';

const rootEl = document.getElementById('app');
const root = createRoot(rootEl);

root.render(App());
```
- React 18부터 `ReactDOM.render()` 대신 `createRoot().render()` 방식이 권장되면서, 컴포넌트 렌더링 진입점을 명확하게 분리하는 구조 도입
- 해당 패턴을 참고하여 createRoot 함수 내부에서 렌더 타겟을 기억하고, 이후 render(vdom)을 통해 Virtual DOM을 실제 DOM으로 그리도록 구현

### 4. 결과물
![화면 기록 2025-04-03 오전 1 17 57](https://github.com/user-attachments/assets/a7454be4-d7ff-4c17-8e42-43f120566556)

```jsx
// App.jsx
export default function App() {
  return (
    <>
      <h1 style={{ color: 'blue' }}>React Test</h1>
      <p>렌더링 테스트 중입니다.</p>
      <button onClick={() => alert('클릭!')}>버튼</button>
    </>
  );
}
```
![스크린샷 2025-04-03 오전 1 15 44](https://github.com/user-attachments/assets/38a083b8-c209-406d-a7d3-0108bd0af2b8)